### PR TITLE
Small fix to addItem in postman.json

### DIFF
--- a/test/postman.json
+++ b/test/postman.json
@@ -63,9 +63,9 @@
                         "method": "POST",
                         "header": [],
                         "url": {
-                            "raw": "{{baseUrl}}/orders/addItem/{order_id}/{item_id}",
+                            "raw": "{{baseUrl}}/orders/addItem/{order_id}/{item_id}/{quantity}",
                             "host": ["{{baseUrl}}"],
-                            "path": ["orders", "addItem", "{order_id}", "{item_id}"]
+                            "path": ["orders", "addItem", "{order_id}", "{item_id}", "{quantity}"]
                         }
                     },
                     "response": []


### PR DESCRIPTION
Official documentation contains an error that emits the quantity field from the addItem POST